### PR TITLE
Removed unused library refs from csproj files

### DIFF
--- a/src/Configuration/StatsdConfiguration.csproj
+++ b/src/Configuration/StatsdConfiguration.csproj
@@ -35,10 +35,6 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -34,10 +34,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ICommandType.cs" />


### PR DESCRIPTION
System.Data.DataSetExtensions exists only to tell you that you haven't pruned unused refs.
