### PR TITLE
Use namespace and assembly name StatsdClient.Configuration

### DIFF
--- a/src/Configuration/Naming.cs
+++ b/src/Configuration/Naming.cs
@@ -1,6 +1,6 @@
 ﻿using System.Configuration;
 
-namespace Configuration
+namespace StatsdClient.Configuration
 {
     public static class Naming
     {

--- a/src/Configuration/StatsdConfiguration.csproj
+++ b/src/Configuration/StatsdConfiguration.csproj
@@ -8,8 +8,8 @@
     <ProjectGuid>{11FB3391-9FA5-433B-A0C4-352BD770378F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Configuration</RootNamespace>
-    <AssemblyName>Configuration</AssemblyName>
+    <RootNamespace>StatsdClient.Configuration</RootNamespace>
+    <AssemblyName>StatsdClient.Configuration</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />

--- a/src/Tests/NamingIntegrationTests.cs
+++ b/src/Tests/NamingIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using Configuration;
+﻿using StatsdClient.Configuration;
 using NUnit.Framework;
 
 namespace Tests


### PR DESCRIPTION
instead of just "Configuration"
So that we know what it is when it's in the bin folder
As per this issue: https://github.com/goncalopereira/statsd-csharp-client/issues/9
