### PR TITLE
Add ability to test Metrics

### DIFF
--- a/src/Tests/MetricIntegrationTests.cs
+++ b/src/Tests/MetricIntegrationTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Configuration;
+using NUnit.Framework;
+using StatsdClient;
+using Tests.Helpers;
+
+
+namespace Tests
+{
+    [TestFixture]
+    public class MetricIntegrationTests
+    {
+        private UdpListener udpListener;
+        private Thread listenThread;
+        private int serverPort = Convert.ToInt32(ConfigurationManager.AppSettings["StatsdServerPort"]);
+        private string serverName = ConfigurationManager.AppSettings["StatsdServerName"];
+
+        [TestFixtureSetUp]
+        public void SetUpUdpListener() 
+        {
+            udpListener = new UdpListener(serverName, serverPort);
+            var metricsConfig = new MetricsConfig { StatsdServerName = serverName };
+            StatsdClient.Metrics.Configure(metricsConfig);
+        }
+
+        [TestFixtureTearDown]
+        public void TearDownUdpListener() 
+        {
+            udpListener.Dispose();
+        }
+
+        [SetUp]
+        public void StartUdpListenerThread()
+        {
+            listenThread = new Thread(new ThreadStart(udpListener.Listen));
+            listenThread.Start();
+        }
+
+        // Test helper. Waits until the listener is done receiving a message,
+        // then asserts that the passed string is equal to the message received.
+        private void AssertWasReceived(string shouldBe)
+        {
+                // Stall until the the listener receives a message or times out 
+                while(listenThread.IsAlive);
+                Assert.AreEqual(shouldBe, udpListener.GetAndClearLastMessage());
+
+        }
+
+        [Test]
+        public void _udp_listener_sanity_test()
+        {
+            var client = new StatsdUDP(ConfigurationManager.AppSettings["StatsdServerName"],
+                                       Convert.ToInt32(ConfigurationManager.AppSettings["StatsdServerPort"]));
+            client.Send("iamnotinsane!");
+            AssertWasReceived("iamnotinsane!");
+
+        }
+
+        [Test]
+        public void counter()
+        {
+            Metrics.Counter("counter");
+            AssertWasReceived("counter:1|c");
+        }
+    }
+}
+

--- a/src/Tests/StatsdClient.Tests.csproj
+++ b/src/Tests/StatsdClient.Tests.csproj
@@ -53,6 +53,8 @@
     <Compile Include="UDPSmokeTests.cs" />
     <Compile Include="StatsdUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MetricIntegrationTests.cs" />
+    <Compile Include="UdpListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/src/Tests/UdpListener.cs
+++ b/src/Tests/UdpListener.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Configuration;
+using System.Text;
+
+namespace Tests
+{
+    namespace Helpers
+    {
+        // A small UDP server that can be used for testing.
+        // Stores the last message that was received by the server
+        // until it is accessed using GetAndClearLastMessage().
+
+        // By design received messages can only be read once. This
+        // allows one instance of the listener to be used across
+        // multiple tests without risk of the results of previous tests
+        // affecting the current one.
+
+        // Intended use:
+        // udpListener = new UdpListener(serverName, serverPort);
+        // listenThread = new Thread(new ThreadStart(udpListener.Listen));
+        // listenThread.Start();
+        // { send something to the listener }
+        // while(listenThread.IsAlive); // wait for listen thread to receive message or time out
+        // received_message = udpListener.GetAndClearLastMessage()
+        // { make sure that the received message is what was expected }
+        public class UdpListener : IDisposable 
+        {
+            byte[] lastReceivedBytes;
+            IPEndPoint localIpEndPoint;
+            IPEndPoint senderIpEndPoint;
+            UdpClient socket;
+
+            public UdpListener(string hostname, int port) 
+            {
+                lastReceivedBytes = new byte[1024];
+                localIpEndPoint = new IPEndPoint(IPAddress.Parse(hostname), port);
+                socket = new UdpClient(localIpEndPoint);
+                socket.Client.ReceiveTimeout = 5000;
+                senderIpEndPoint = new IPEndPoint(IPAddress.Any, 0);
+            }
+
+            // Sets lastReceivedBytes with the last message received, or null if it
+            // times out. This call is blocking; you may want to run it in a
+            // thread while you send the message.
+            public void Listen()
+            {
+                try
+                {
+                    lastReceivedBytes = socket.Receive(ref senderIpEndPoint);
+                }
+                catch (SocketException ex)
+                {
+                    // If we timeout, just set the last received message to null (which
+                    // will behave as expected in assertions).
+                    // If we get another error, propagate it upwards 
+                    if (ex.ErrorCode == 10060) // WSAETIMEDOUT; Timeout error
+                        lastReceivedBytes = null;
+                    else
+                        throw ex;
+                }
+            }
+
+            // Encode lastReceivedBytes as a string, and clear them before
+            // returning the string. This allows us to use the same UdpListener instance
+            // for every test we we never have to worry about a message received from a
+            // previous test giving us a false positive.
+            public string GetAndClearLastMessage()
+            {
+                if (lastReceivedBytes == null)
+                    return null;
+
+                string encodedMessage = Encoding.ASCII.GetString(lastReceivedBytes, 0,
+                                                                 lastReceivedBytes.Length);
+                lastReceivedBytes = null;
+                return encodedMessage;
+
+            }
+
+            public void Dispose() 
+            {
+                socket.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I noticed that there aren't currently any tests for calls via the static `Metrics` class, so I wrote a way to test them.

When I initially went to write tests I thought it would be as simple as mocking out StatsUDP. However, I quickly found out that [Rhino Mocks doesn't support mocking static methods and variables](http://stackoverflow.com/questions/540239/mocking-static-methods-using-rhino-mocks). One solution could have been to create a proxy class that wraps Metrics methods into instance methods, but I wasn't thrilled with this solution. Instead, I figured it would be better to just write some full blown integration tests.

You may have to change the test App.config to set `StatsdServerName` to `127.0.0.1` in order for this to work. Also, if you run it on port `8125` make sure that you don't have another statsd running server running on the machine.

Please let me know if you can think of a better way to do this :)

Right now there are minimal tests, but I'll probably expand them out in the next few days. If you want this PR I can add tests that are not Datadog-specific to your repo too.
