### PR TITLE
Stopwatch: introducing "ElapsedTime"

### DIFF
--- a/src/StatsdClient/Stopwatch.cs
+++ b/src/StatsdClient/Stopwatch.cs
@@ -1,9 +1,14 @@
+using System;
+
 namespace StatsdClient
 {
     public interface IStopwatch
     {
         void Start();
         void Stop();
+        TimeSpan ElapsedTime { get; }
+
+        [Obsolete("use ElapsedTime property")]
         int ElapsedMilliseconds();
     }
 
@@ -21,9 +26,23 @@ namespace StatsdClient
             _stopwatch.Stop();
         }
 
+        public TimeSpan ElapsedTime
+        {
+            get {
+                var milliseconds = (double)unchecked(_stopwatch.ElapsedMilliseconds);
+                return TimeSpan.FromMilliseconds(milliseconds);
+            }
+        }
+
+        [Obsolete("use ElapsedTime property")]
         public int ElapsedMilliseconds()
         {
-            return (int) unchecked(_stopwatch.ElapsedMilliseconds);
+            double milliseconds = ElapsedTime.TotalMilliseconds;
+            if (milliseconds > int.MaxValue)
+            {
+                throw new InvalidOperationException("Please use new API 'ElapsedTime' instead of 'ElapsedMilliseconds()', as your value just overflowed for this old API");
+            }
+            return (int)milliseconds;
         }
     }
 }


### PR DESCRIPTION
If using a method ElapsedMilliseconds() instead of a property,
(like .NET's Stopwatch has) wasn't enough of a fuck-up**, turns
out that ElapsedMilliseconds() returned int instead of .NET's
Stopwatch's long. So this was making a useless round that could
actually result in hideous bugs because it was even marked as
(unchecked).

Let's then fix it in a prettier way, having a TimeSpan which then
can return the unit of time you wish, instead of suffixing it with
"Milliseconds" (surrendering to PrimitiveObsession).

** because you cannot really fix this problem without breaking
backwards-compatibility (as you cannot have both a method Foo()
and a property Foo in a given class)