### PR TITLE
Stopwatch: rename 'ElapsedTime' to 'Elapsed'

### DIFF
--- a/src/StatsdClient/Stopwatch.cs
+++ b/src/StatsdClient/Stopwatch.cs
@@ -6,9 +6,9 @@ namespace StatsdClient
     {
         void Start();
         void Stop();
-        TimeSpan ElapsedTime { get; }
+        TimeSpan Elapsed { get; }
 
-        [Obsolete("use ElapsedTime property")]
+        [Obsolete("use Elapsed property")]
         int ElapsedMilliseconds();
     }
 
@@ -26,21 +26,20 @@ namespace StatsdClient
             _stopwatch.Stop();
         }
 
-        public TimeSpan ElapsedTime
+        public TimeSpan Elapsed
         {
             get {
-                var milliseconds = (double)unchecked(_stopwatch.ElapsedMilliseconds);
-                return TimeSpan.FromMilliseconds(milliseconds);
+                return _stopwatch.Elapsed;
             }
         }
 
-        [Obsolete("use ElapsedTime property")]
+        [Obsolete("use Elapsed property")]
         public int ElapsedMilliseconds()
         {
-            double milliseconds = ElapsedTime.TotalMilliseconds;
+            double milliseconds = Elapsed.TotalMilliseconds;
             if (milliseconds > int.MaxValue)
             {
-                throw new InvalidOperationException("Please use new API 'ElapsedTime' instead of 'ElapsedMilliseconds()', as your value just overflowed for this old API");
+                throw new InvalidOperationException("Please use new API 'Elapsed' instead of 'ElapsedMilliseconds()', as your value just overflowed for this old API");
             }
             return (int)milliseconds;
         }


### PR DESCRIPTION
Turns out that .NET's Stopwatch already has a TimeSpan property,
and it's named 'Elapsed', not 'ElapsedTime', so let's be consistent
here.

This also simplifies the code for it, to be just a wrapper to
the inner stopwatch's TimeSpan object.