### PR TITLE
Fix Timer to report ElapsedMilliseconds instead of the Milliseconds component of the Elapsed Timespan

### DIFF
--- a/src/StatsdClient/MetricsTimer.cs
+++ b/src/StatsdClient/MetricsTimer.cs
@@ -23,7 +23,7 @@ namespace StatsdClient
             {
                 _disposed = true;
                 _stopWatch.Stop();
-                Metrics.Timer(_name, _stopWatch.Elapsed.Milliseconds, _sampleRate);
+                Metrics.Timer(_name, _stopWatch.ElapsedMilliseconds, _sampleRate);
             }
         }
     }

--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -190,7 +190,7 @@ namespace StatsdClient
                 stopwatch.Stop();
                 if (RandomGenerator.ShouldSend(sampleRate))
                 {
-                    Send<Timing>(statName, stopwatch.Elapsed.Milliseconds);
+                    Send<Timing>(statName, stopwatch.ElapsedMilliseconds);
                 }
             }
         }

--- a/src/StatsdClient/Stopwatch.cs
+++ b/src/StatsdClient/Stopwatch.cs
@@ -27,5 +27,10 @@ namespace StatsdClient
         {
             get { return _stopwatch.Elapsed; }
         }
+
+        public int ElapsedMilliseconds
+        {
+            get { return _stopwatch.ElapsedMilliseconds; }
+        }
     }
 }

--- a/src/Tests/StatsdTests.cs
+++ b/src/Tests/StatsdTests.cs
@@ -83,6 +83,7 @@ namespace Tests
 
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
                 var statsd = new Statsd(_udp, _randomGenerator, _stopwatch);
@@ -98,6 +99,7 @@ namespace Tests
 
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
                 _randomGenerator.ShouldSend(0).ReturnsForAnyArgs(true);
@@ -115,6 +117,7 @@ namespace Tests
 
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
                 _randomGenerator.ShouldSend(0).ReturnsForAnyArgs(false);
@@ -132,6 +135,7 @@ namespace Tests
 
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
                 var s = new Statsd(_udp, _randomGenerator, _stopwatch);
@@ -148,6 +152,7 @@ namespace Tests
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
                 var s = new Statsd(_udp, _randomGenerator, _stopwatch);
@@ -162,6 +167,7 @@ namespace Tests
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
                 _randomGenerator.ShouldSend(0).ReturnsForAnyArgs(true);
@@ -179,6 +185,7 @@ namespace Tests
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
                 _randomGenerator.ShouldSend(0).ReturnsForAnyArgs(false);
@@ -195,6 +202,7 @@ namespace Tests
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
                 var s = new Statsd(_udp, _randomGenerator, _stopwatch);
@@ -209,6 +217,7 @@ namespace Tests
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
                 stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
+                stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
                 var s = new Statsd(_udp, _randomGenerator, _stopwatch);


### PR DESCRIPTION
It seems that the timer has been incorrectly reporting times that are greater than one second. The `Timespan` structure will only report the milliseconds component of the time span, i.e. from 0 to 999, when asked for `Timespan.Milliseconds`.  

`Timespan.TotalMilliseconds` will return a double. Or the `Stopwatch` itself just provides the `ElapsedMilliseconds` property for easy access as an integer here.

![ms](https://cloud.githubusercontent.com/assets/19397149/23770154/3238fc36-04cf-11e7-9452-0f6b2e089950.PNG)
