### PR TITLE
Fix thread safety issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.{build}
+version: 3.0.{build}
 configuration: Release
 before_build:
 # matches pinned version in global.json

--- a/src/StatsdClient/IStatsd.cs
+++ b/src/StatsdClient/IStatsd.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Collections.Generic;
 
 namespace StatsdClient
 {
     public interface IStatsd
     {
-        List<string> Commands { get; }
-        
         void Send<TCommandType>(string name, int value) where TCommandType : IAllowsInteger;
         void Add<TCommandType>(string name, int value) where TCommandType : IAllowsInteger;
 

--- a/src/StatsdClient/Properties/AssemblyInfo.cs
+++ b/src/StatsdClient/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2012")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
Changes from a `List` to a `ConcurrentQueue` and removes unneeded internal state passing via that collection when we're sending a single metric.

Closes #61 