### PR TITLE
Use ElapsedMilliseconds from Stopwatch for timing

### DIFF
--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -179,7 +179,7 @@ namespace StatsdClient
                 stopwatch.Stop();
                 if (RandomGenerator.ShouldSend(sampleRate))
                 {
-                    Add<Timing>(statName, stopwatch.Elapsed.Milliseconds);
+                    Add<Timing>(statName, stopwatch.ElapsedMilliseconds);
                 }
             }
         }

--- a/src/StatsdClient/Stopwatch.cs
+++ b/src/StatsdClient/Stopwatch.cs
@@ -1,12 +1,10 @@
-using System;
-
 namespace StatsdClient
 {
     public interface IStopwatch
     {
         void Start();
         void Stop();
-        TimeSpan Elapsed { get; }
+        int ElapsedMilliseconds { get; }
     }
 
     public class Stopwatch : IStopwatch
@@ -23,14 +21,9 @@ namespace StatsdClient
             _stopwatch.Stop();
         }
 
-        public TimeSpan Elapsed
-        {
-            get { return _stopwatch.Elapsed; }
-        }
-
         public int ElapsedMilliseconds
         {
-            get { return _stopwatch.ElapsedMilliseconds; }
+            get { return (int)_stopwatch.ElapsedMilliseconds; }
         }
     }
 }

--- a/src/Tests/StatsdTests.cs
+++ b/src/Tests/StatsdTests.cs
@@ -82,7 +82,6 @@ namespace Tests
                 const string statName = "name";
 
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
@@ -98,7 +97,6 @@ namespace Tests
                 const string statName = "name";
 
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
@@ -116,7 +114,6 @@ namespace Tests
                 const string statName = "name";
 
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
@@ -134,7 +131,6 @@ namespace Tests
                 const string statName = "name";
 
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
@@ -151,7 +147,6 @@ namespace Tests
             {
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
@@ -166,7 +161,6 @@ namespace Tests
             {
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
@@ -184,7 +178,6 @@ namespace Tests
             {
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
                 _randomGenerator = Substitute.For<IRandomGenerator>();
@@ -201,7 +194,6 @@ namespace Tests
             {
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 
@@ -216,7 +208,6 @@ namespace Tests
             {
                 const string statName = "name";
                 var stopwatch = Substitute.For<IStopwatch>();
-                stopwatch.Elapsed.Returns(TimeSpan.FromMilliseconds(500));
                 stopwatch.ElapsedMilliseconds.Returns(500);
                 _stopwatch.Get().Returns(stopwatch);
 


### PR DESCRIPTION
* As pointed out in PR #70, Elapsed.Milliseconds only gives milliseconds since last second leaving off lots of time!
* Given we're timing milliseconds, I find the thought of any timed operation taking more than 24.8 DAYS pretty unlikely and those people will get a stack overlow exception converting from long to int :)
* While public the interface is meant for internal use so I'm ok with some primitive obsession for this need
* Breaking interface change as part of the 3.x release